### PR TITLE
Update ngx_http_rdns_module.c

### DIFF
--- a/ngx_http_rdns_module.c
+++ b/ngx_http_rdns_module.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2012-2013 CJSC Flant (flant.com)
  */
 
-#include <nginx.h>
 #include <ngx_config.h>
+#include <nginx.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
 


### PR DESCRIPTION
fix for 1.7.12 compile errors.